### PR TITLE
Fixed path to change for require statement

### DIFF
--- a/payment-gateways/stripe.md
+++ b/payment-gateways/stripe.md
@@ -19,7 +19,7 @@ bundle install
 Edit your `application.js` file and add the following
 
 ```
-::app/assets/application.js
+::app/assets/javascripts/application.js
 //= require shoppe/stripe/form_handler
 ```
 


### PR DESCRIPTION
The require statement needs to be in the javascripts folder or else the application will not render the stripe form handler.