### PR TITLE
correct some typos in documentation

### DIFF
--- a/extending.md
+++ b/extending.md
@@ -124,6 +124,6 @@ Many thanks,
 <%= Shoppe.settings.email_address %>
 ```
 
-The main part of the Gem has neen completed. All you need to do now is push the gem to
+The main part of the Gem has been completed. All you need to do now is push the gem to
 Rubygems (if you want) and add it to the Gemfile of your project and that's it! When a new
 order has been received, staff will receive an email saying so.

--- a/tutorials/checking-out.md
+++ b/tutorials/checking-out.md
@@ -47,7 +47,7 @@ end
 ```
 
 On our checkout page, we want to display the contents of the basket as well as providing
-a form for visitor to enter their details.
+a form for visitors to enter their details.
 
 ```rhtml
 ::app/views/orders/checkout.html.erb

--- a/tutorials/getting-started.md
+++ b/tutorials/getting-started.md
@@ -19,6 +19,6 @@ setup.
 * [Customer baskets](baskets)
 * [Checking out](checking-out)
 
-The final appication built in this tutorial is [available on GitHub](https://github.com/tryshoppe/getting-started-tutorial).
+The final application built in this tutorial is [available on GitHub](https://github.com/tryshoppe/getting-started-tutorial).
 If you get stuck or need further information, this would be an excellent place to
 download a working copy of the application.


### PR DESCRIPTION
Hi,

I found some small typos in the Shoppe documentation